### PR TITLE
Force RPM processing for libsolv

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -804,6 +804,7 @@ dnf_sack_set_arch (DnfSack *sack, const gchar *value, GError **error)
     g_debug("Architecture is: %s", arch);
     g_free (priv->arch);
     priv->arch = g_strdup(arch);
+    pool_setdisttype(pool, DISTTYPE_RPM);
     pool_setarch(pool, arch);
 
     /* Since one of commits after 0.6.20 libsolv allowes custom arches


### PR DESCRIPTION
libsolv will by default assume if it is built for Debian, Arch or Haiku systems, then the architecture name for platform-independent packages is not `noarch` (`all` on Debian, `any` on the others). This causes dnf to fail to run on those OSes, as it considers `package redhat-rpm-config-115-1.el8.noarch does not have a compatible architecture` etc.

Since libdnf is purely for RPM use, force it to always initialize libsolv in RPM mode, with `noarch` as the noarch name.